### PR TITLE
Update vaadin-archetype-liferay-portlet to Vaadin 8

### DIFF
--- a/vaadin-archetype-liferay-portlet/pom.xml
+++ b/vaadin-archetype-liferay-portlet/pom.xml
@@ -1,7 +1,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <name>Vaadin 7.2 Liferay 6.2-GA2 archetype</name>
+    <name>Vaadin 8.0 Liferay 6.2-GA1 archetype</name>
 
     <parent>
         <groupId>com.vaadin</groupId>
@@ -20,7 +20,7 @@
     <url>http://vaadin.com</url>
     <inceptionYear>2014</inceptionYear>
     <description>
-        This archetype generates a self-contained Vaadin 7 Liferay portlet.
+        This archetype generates a self-contained Vaadin 8 Liferay portlet.
         It packages all Vaadin static resources (widgetset, theme etc.)
         and doesn't make use of portal-provided resources.
 

--- a/vaadin-archetype-liferay-portlet/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/vaadin-archetype-liferay-portlet/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -7,7 +7,7 @@
 
 	<requiredProperties>
 		<requiredProperty key="liferayVersion">
-			<defaultValue>[6.1.0,)</defaultValue>
+			<defaultValue>[6.2.0-ga1,)</defaultValue>
 		</requiredProperty>
 		<requiredProperty key="uiClassName">
 			<defaultValue>MyPortletUI</defaultValue>
@@ -23,7 +23,7 @@
 			<defaultValue>Hello World</defaultValue>
 		</requiredProperty>
 		<requiredProperty key="portletKeywords">
-			<defaultValue>Vaadin 7</defaultValue>
+			<defaultValue>Vaadin 8</defaultValue>
 		</requiredProperty>
 		<requiredProperty key="portletDescription">
 			<defaultValue>Write a short description about your portlet.</defaultValue>

--- a/vaadin-archetype-liferay-portlet/src/main/resources/archetype-resources/src/main/java/__uiClassName__.java
+++ b/vaadin-archetype-liferay-portlet/src/main/resources/archetype-resources/src/main/java/__uiClassName__.java
@@ -16,7 +16,6 @@ import com.vaadin.server.VaadinRequest;
 import com.vaadin.server.WrappedPortletSession;
 import com.vaadin.shared.ui.label.ContentMode;
 import com.vaadin.ui.Button;
-import com.vaadin.ui.Button.ClickEvent;
 import com.vaadin.ui.Label;
 import com.vaadin.ui.UI;
 import com.vaadin.ui.VerticalLayout;
@@ -37,8 +36,7 @@ public class ${uiClassName} extends UI {
         setContent(layout);
 
         final Button button = new Button("Click Me");
-        button.addClickListener(new Button.ClickListener() {
-            public void buttonClick(ClickEvent event) {
+        button.addClickListener(event -> {
                 layout.addComponent(new Label(
                         "Hello, World!<br>This is portlet "
                                 + portletContextName
@@ -48,7 +46,7 @@ public class ${uiClassName} extends UI {
                         ContentMode.HTML));
 
             }
-        });
+        );
         layout.addComponent(button);
     }
 


### PR DESCRIPTION
Updated Liferay version to 6.2.0-ga1 (support level for 8).
Verified with Liferay 6.2.0-GA5.

Fixes vaadin/framework8-issues#350

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/archetypes/102)
<!-- Reviewable:end -->
