### PR TITLE
Use browsable scm repository url by default.

### DIFF
--- a/vaadin-archetype-widget/src/main/resources/archetype-resources/__artifactId__-addon/pom.xml
+++ b/vaadin-archetype-widget/src/main/resources/archetype-resources/__artifactId__-addon/pom.xml
@@ -37,7 +37,7 @@
 	</organization>
 
 	<scm>
-		<url>git://github.com/mygithubaccount/\${componentClassName}.git</url>
+		<url>https://github.com/mygithubaccount/${componentClassName}</url>
 		<connection>scm:git:git://github.com/mygithubaccount/\${componentClassName}.git</connection>
 		<developerConnection>scm:git:ssh://git@github.com:/mygithubaccount/\${componentClassName}.git</developerConnection>
 		<tag>\${componentClassName} add-on for Vaadin</tag>


### PR DESCRIPTION
Maven documentation suggest the following "url: A publicly browsable repository. For example, via ViewCVS." ( http://maven.apache.org/pom.html#SCM )

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/archetypes/116)
<!-- Reviewable:end -->
