### PR TITLE
Update archetypes root POM to enable publishing it

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,13 +22,15 @@
     <connection>https://github.com/vaadin/archetypes.git</connection>
     <developerConnection>git@github.com:vaadin/archetypes.git</developerConnection>
   </scm>
+  <issueManagement>
+    <system>GitHub Issues</system>
+    <url>https://github.com/vaadin/archetypes/issues</url>
+  </issueManagement>
   <modules>
     <module>vaadin-archetype-application</module>
     <module>vaadin-archetype-application-example</module>
     <module>vaadin-archetype-application-multimodule</module>
-    <module>vaadin-archetype-jee-application</module>
     <module>vaadin-archetype-liferay-portlet</module>
-    <module>vaadin-archetype-liferay-portlet-sharedlib</module>
     <module>vaadin-archetype-widget</module>
   </modules>
   <licenses>
@@ -38,5 +40,18 @@
       <distribution>repo</distribution>
     </license>
   </licenses>
+  
+  <profiles>
+    <profile>
+      <id>archetypes-published-separately</id>
+      <activation>
+        <activeByDefault>false</activeByDefault>
+      </activation>
+      <modules>
+        <module>vaadin-archetype-jee-application</module>
+        <module>vaadin-archetype-liferay-portlet-sharedlib</module>
+      </modules>
+    </profile>
+  </profiles>
 
 </project>


### PR DESCRIPTION
By default, only build the archetypes published with the framework.
Use separate profile for building other archetypes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/archetypes/121)
<!-- Reviewable:end -->
