### PR TITLE
Escape property vaadin.version

### DIFF
--- a/vaadin-archetype-application/src/main/resources/archetype-resources/pom.xml
+++ b/vaadin-archetype-application/src/main/resources/archetype-resources/pom.xml
@@ -118,7 +118,7 @@
             <plugin>
                 <groupId>com.vaadin</groupId>
                 <artifactId>vaadin-maven-plugin</artifactId>
-                <version>${vaadin.version}</version>
+                <version>\${vaadin.version}</version>
                 <executions>
                     <execution>
                         <goals>


### PR DESCRIPTION
Value for `vaadin-maven-plugin` version is being replaced with the version defined when archetype is generated.