### PR TITLE
Added the pluginrepository for  Maven central

### DIFF
--- a/vaadin-archetype-application/src/main/resources/archetype-resources/pom.xml
+++ b/vaadin-archetype-application/src/main/resources/archetype-resources/pom.xml
@@ -17,7 +17,7 @@
 
     <repositories>
         <!-- The order of definitions matters. Explicitly defining central here to make sure it has the highest priority. -->
-
+       
         <!-- Main Maven repository -->
         <repository>
             <id>central</id>
@@ -35,7 +35,15 @@
             </snapshots>
         </repository>
     </repositories>
-
+    <pluginRepositories>
+        <pluginRepository>
+            <id>central</id>
+            <url>https://repo.maven.apache.org/maven2</url>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </pluginRepository>        
+    </pluginRepositories>
     <dependencyManagement>
         <dependencies>
             <dependency>


### PR DESCRIPTION
There is a problem with maven central http that can be fixed with defining https in pom.xml

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/archetypes/162)
<!-- Reviewable:end -->
