### PR TITLE
Define empty relative path to make IntelliJ happy

### DIFF
--- a/vaadin-archetype-spring-application/src/main/resources/archetype-resources/pom.xml
+++ b/vaadin-archetype-spring-application/src/main/resources/archetype-resources/pom.xml
@@ -16,6 +16,7 @@
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
         <version>3.0.4</version>
+        <relativePath/>
     </parent>
 
     <dependencyManagement>


### PR DESCRIPTION
Without this, (latest?) IntelliJ fails to setup classpath properly, CLI compiles just fine. With this all works.
