### PR TITLE
chore: bump jetty maven plugin to 11.0.21

### DIFF
--- a/vaadin-archetype-application/src/main/resources/archetype-resources/pom.xml
+++ b/vaadin-archetype-application/src/main/resources/archetype-resources/pom.xml
@@ -55,7 +55,7 @@
             <plugin>
                 <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-maven-plugin</artifactId>
-                <version>11.0.14</version>
+                <version>11.0.21</version>
                 <configuration>
                     <!--
                     Configures automatic reload of Jetty server


### PR DESCRIPTION
Fixes runtime error when running the application generated by the artifact with Java 21.

Fixes #213